### PR TITLE
[qa] Add charging hysteresis configuration. JB#57297

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,8 @@ oneshotdir = /usr/lib/oneshot.d
 sysctldir = /etc/sysctl.d
 # The directory to install sailjail configs
 sailjailconfdir = /etc/sailjail/config
+# The directory to install mce configs
+mceconfdir = /etc/mce
 
 .PHONY: all
 all: $(REBOOTTOOL)
@@ -35,6 +37,8 @@ install:
 	$(INSTALL) sysctl/* $(DESTDIR)$(sysctldir)
 	$(INSTALLDIR) -d $(DESTDIR)$(sailjailconfdir)
 	$(INSTALL) sailjail/* $(DESTDIR)$(sailjailconfdir)
+	$(INSTALLDIR) -d $(DESTDIR)$(mceconfdir)
+	$(INSTALL) mce/*.conf $(DESTDIR)$(mceconfdir)
 
 .PHONY: clean
 clean:

--- a/mce/70-qa-charging.conf
+++ b/mce/70-qa-charging.conf
@@ -1,0 +1,3 @@
+/system/osso/dsm/charging/charging_mode=2
+/system/osso/dsm/charging/limit_disable=95
+/system/osso/dsm/charging/limit_enable=50

--- a/rpm/qa-tools.spec
+++ b/rpm/qa-tools.spec
@@ -42,6 +42,7 @@ make %{?_smp_mflags}
 %{_oneshotdir}/*
 %{_sysconfdir}/sysctl.d/*
 %{_sysconfdir}/sailjail/config/*.conf
+%{_sysconfdir}/mce/*.conf
 
 %post hooks
 if [ "$1" -eq 1 ]; then

--- a/rpm/qa-tools.spec
+++ b/rpm/qa-tools.spec
@@ -18,8 +18,6 @@ Requires(post): /usr/bin/ssu
 Requires: ssu
 Requires: jolla-preload-ambiences-default-ambience
 %{_oneshot_requires_post}
-# Removed in JB#49024 / JB#35113
-Obsoletes: jolla-firstsession-qa <= 0.50
 
 %description hooks
 %{summary}.


### PR DESCRIPTION
To limit charging cycles / time in battery full state with constantly
connected qa devices, configure charging hysteresis so that charging
is disabled once battery level reaches 95% and is kept disabled until
battery level drops below 50%.

This has the same effect as changing settings at runtime as follows:

mcetool --set-charging-mode=apply-thresholds\
 --set-charging-enable-limit=50\
 --set-charging-disable-limit=95

Signed-off-by: Simo Piiroinen <simo.piiroinen@jolla.com>